### PR TITLE
Remove test-transform-tN targets from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TARGETS = test-crc32 test-u8 test-u16 test-u32 test-u64 test-float test-double test-longdouble test-u128 test-u32-cmp test-memcmp test-strcmp test-transform test-extint test-transform-t1 test-transform-t2 test-transform-t3 test-transform-t4 test-transform-t5 test-transform-t6 test-transform-t7 test-transform-t8
+TARGETS = test-crc32 test-u8 test-u16 test-u32 test-u64 test-float test-double test-longdouble test-u128 test-u32-cmp test-memcmp test-strcmp test-transform test-extint
 
 all:
 	@echo Use test.sh to perform the test.


### PR DESCRIPTION
These were introduced in commit 86d9dec; I'm fairly sure they were added to test timeouts and left in accidentally.