### PR TITLE
Fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 test-*
-+test-*.c
+!test-*.c
 
 afl++.dic
 in
+out-*/


### PR DESCRIPTION
I was using the wrong character for whitelisting files, and I forgot to include the output dirs.