### PR TITLE
Add "input length" and "sorted sequence" challenges.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TARGETS = test-crc32 test-u8 test-u16 test-u32 test-u64 test-float test-double test-longdouble test-u128 test-u32-cmp test-memcmp test-strcmp test-transform test-extint
+TARGETS = test-crc32 test-u8 test-u16 test-u32 test-u64 test-float test-double test-longdouble test-u128 test-u32-cmp test-memcmp test-strcmp test-transform test-extint test-sorted test-input-len
 
 all:
 	@echo Use test.sh to perform the test.

--- a/test-input-len.c
+++ b/test-input-len.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <strings.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+int LLVMFuzzerTestOneInput(uint8_t *, size_t len) {
+  if (len < 1024)
+    return 0;
+
+  abort();
+  return 0;
+}
+
+#ifdef __AFL_COMPILER
+int main(int argc, char **argv) {
+
+  unsigned char buf[64];
+  ssize_t       len;
+  int           fd = 0;
+  if (argc > 1) fd = open(argv[1], O_RDONLY);
+
+  if ((len = read(fd, buf, sizeof(buf))) <= 0) exit(0);
+
+  LLVMFuzzerTestOneInput(buf, len);
+  exit(0);
+}
+#endif
+

--- a/test-sorted.c
+++ b/test-sorted.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <strings.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+int LLVMFuzzerTestOneInput(uint8_t *buf, size_t len) {
+  const size_t SORTED_LEN = 64;
+
+  if (len < SORTED_LEN) {
+    fprintf(stderr, "wrong size\n");
+    return 0;
+  }
+
+  for (size_t i = 1; i < SORTED_LEN; i++) {
+    if (buf[i] <= buf[i - 1]) {
+        fprintf(stderr, "item %u isn't greater than previous item\n", (uint32_t)i);
+        return 0;
+    }
+  }
+
+  abort();
+
+  return 0;
+}
+
+#ifdef __AFL_COMPILER
+int main(int argc, char **argv) {
+
+  unsigned char buf[64];
+  ssize_t       len;
+  int           fd = 0;
+  if (argc > 1) fd = open(argv[1], O_RDONLY);
+
+  if ((len = read(fd, buf, sizeof(buf))) <= 0) exit(0);
+
+  LLVMFuzzerTestOneInput(buf, len);
+  exit(0);
+}
+#endif
+


### PR DESCRIPTION
They're both conceptually pretty dumb, and yet they both completely stump `afl++`.

The sorting test stumps `libfuzzer` too.